### PR TITLE
refactor: 💡 Change to run lsof command only once

### DIFF
--- a/EjectKey.xcodeproj/project.pbxproj
+++ b/EjectKey.xcodeproj/project.pbxproj
@@ -31,6 +31,7 @@
 		D6288B4728A0CE2E00F80FF1 /* ShortcutsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D6288B4628A0CE2E00F80FF1 /* ShortcutsView.swift */; };
 		D6347FC6297E8AE60084CF7E /* SwiftShell in Frameworks */ = {isa = PBXBuildFile; productRef = D6347FC5297E8AE60084CF7E /* SwiftShell */; };
 		D637A85F2974374C00C6DD7D /* LaunchAtLogin in Frameworks */ = {isa = PBXBuildFile; productRef = D637A85E2974374C00C6DD7D /* LaunchAtLogin */; };
+		D65AB5612A6CAACB00311461 /* Command.swift in Sources */ = {isa = PBXBuildFile; fileRef = D65AB5602A6CAACB00311461 /* Command.swift */; };
 		D65DE2852A19F40D0051AAE3 /* SettingsForm.swift in Sources */ = {isa = PBXBuildFile; fileRef = D65DE2842A19F40D0051AAE3 /* SettingsForm.swift */; };
 		D65DE28C2A19F4F40051AAE3 /* EffectView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D65DE28B2A19F4F40051AAE3 /* EffectView.swift */; };
 		D65DE28E2A1A0A810051AAE3 /* HideSidebarToggle.swift in Sources */ = {isa = PBXBuildFile; fileRef = D65DE28D2A1A0A810051AAE3 /* HideSidebarToggle.swift */; };
@@ -87,6 +88,7 @@
 		D6288B3E289F44D100F80FF1 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
 		D6288B4228A0CBB500F80FF1 /* Shortcuts.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Shortcuts.swift; sourceTree = "<group>"; };
 		D6288B4628A0CE2E00F80FF1 /* ShortcutsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShortcutsView.swift; sourceTree = "<group>"; };
+		D65AB5602A6CAACB00311461 /* Command.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Command.swift; sourceTree = "<group>"; };
 		D65DE2842A19F40D0051AAE3 /* SettingsForm.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsForm.swift; sourceTree = "<group>"; };
 		D65DE28B2A19F4F40051AAE3 /* EffectView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EffectView.swift; sourceTree = "<group>"; };
 		D65DE28D2A1A0A810051AAE3 /* HideSidebarToggle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HideSidebarToggle.swift; sourceTree = "<group>"; };
@@ -219,6 +221,7 @@
 				D696B792291367FD001DD6FE /* Hidden.swift */,
 				D6288B16289EC7A200F80FF1 /* Resize.swift */,
 				D6288B18289EC7B600F80FF1 /* Unique.swift */,
+				D65AB5602A6CAACB00311461 /* Command.swift */,
 				D6EF55AB2962F76C002E36EC /* UpdaterViewModel.swift */,
 				D65DE28D2A1A0A810051AAE3 /* HideSidebarToggle.swift */,
 				D65DE28B2A19F4F40051AAE3 /* EffectView.swift */,
@@ -337,6 +340,7 @@
 				D65DE2852A19F40D0051AAE3 /* SettingsForm.swift in Sources */,
 				D6288B19289EC7B600F80FF1 /* Unique.swift in Sources */,
 				D6EEFE192962C335002B64AA /* Unit.swift in Sources */,
+				D65AB5612A6CAACB00311461 /* Command.swift in Sources */,
 				D6288AE9289EBE5600F80FF1 /* Strings.swift in Sources */,
 				D6288AFA289EC41900F80FF1 /* Observers.swift in Sources */,
 				D65DE28C2A19F4F40051AAE3 /* EffectView.swift in Sources */,

--- a/EjectKey.xcodeproj/project.pbxproj
+++ b/EjectKey.xcodeproj/project.pbxproj
@@ -29,7 +29,6 @@
 		D6288B4128A0CB9800F80FF1 /* KeyboardShortcuts in Frameworks */ = {isa = PBXBuildFile; productRef = D6288B4028A0CB9800F80FF1 /* KeyboardShortcuts */; };
 		D6288B4328A0CBB500F80FF1 /* Shortcuts.swift in Sources */ = {isa = PBXBuildFile; fileRef = D6288B4228A0CBB500F80FF1 /* Shortcuts.swift */; };
 		D6288B4728A0CE2E00F80FF1 /* ShortcutsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D6288B4628A0CE2E00F80FF1 /* ShortcutsView.swift */; };
-		D6347FC6297E8AE60084CF7E /* SwiftShell in Frameworks */ = {isa = PBXBuildFile; productRef = D6347FC5297E8AE60084CF7E /* SwiftShell */; };
 		D637A85F2974374C00C6DD7D /* LaunchAtLogin in Frameworks */ = {isa = PBXBuildFile; productRef = D637A85E2974374C00C6DD7D /* LaunchAtLogin */; };
 		D65AB5612A6CAACB00311461 /* Command.swift in Sources */ = {isa = PBXBuildFile; fileRef = D65AB5602A6CAACB00311461 /* Command.swift */; };
 		D65DE2852A19F40D0051AAE3 /* SettingsForm.swift in Sources */ = {isa = PBXBuildFile; fileRef = D65DE2842A19F40D0051AAE3 /* SettingsForm.swift */; };
@@ -116,7 +115,6 @@
 				D6EF55A92962F714002E36EC /* Sparkle in Frameworks */,
 				D6288B4128A0CB9800F80FF1 /* KeyboardShortcuts in Frameworks */,
 				D6288AEE289EC0E200F80FF1 /* Defaults in Frameworks */,
-				D6347FC6297E8AE60084CF7E /* SwiftShell in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -264,7 +262,6 @@
 				D6B238CD29601E690049CF72 /* DependencyList */,
 				D6EF55A82962F714002E36EC /* Sparkle */,
 				D637A85E2974374C00C6DD7D /* LaunchAtLogin */,
-				D6347FC5297E8AE60084CF7E /* SwiftShell */,
 				D6EDD7F52A5FD752005FFF3F /* Introspect */,
 			);
 			productName = EjectKey;
@@ -305,7 +302,6 @@
 				D637A85D2974374C00C6DD7D /* XCRemoteSwiftPackageReference "LaunchAtLogin-Modern" */,
 				D68DAFAC297993D4009062CB /* XCRemoteSwiftPackageReference "SwiftLintPlugin" */,
 				D68DAFB829799C76009062CB /* XCRemoteSwiftPackageReference "SwiftGenPlugin" */,
-				D6347FC4297E8AE60084CF7E /* XCRemoteSwiftPackageReference "SwiftShell" */,
 				D6EDD7F42A5FD752005FFF3F /* XCRemoteSwiftPackageReference "SwiftUI-Introspect" */,
 			);
 			productRefGroup = D6288AC5289EB5DB00F80FF1;
@@ -628,14 +624,6 @@
 				kind = branch;
 			};
 		};
-		D6347FC4297E8AE60084CF7E /* XCRemoteSwiftPackageReference "SwiftShell" */ = {
-			isa = XCRemoteSwiftPackageReference;
-			repositoryURL = "https://github.com/kareman/SwiftShell";
-			requirement = {
-				branch = master;
-				kind = branch;
-			};
-		};
 		D637A85D2974374C00C6DD7D /* XCRemoteSwiftPackageReference "LaunchAtLogin-Modern" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/sindresorhus/LaunchAtLogin-Modern";
@@ -701,11 +689,6 @@
 			isa = XCSwiftPackageProductDependency;
 			package = D6288B3F28A0CB9800F80FF1 /* XCRemoteSwiftPackageReference "KeyboardShortcuts" */;
 			productName = KeyboardShortcuts;
-		};
-		D6347FC5297E8AE60084CF7E /* SwiftShell */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = D6347FC4297E8AE60084CF7E /* XCRemoteSwiftPackageReference "SwiftShell" */;
-			productName = SwiftShell;
 		};
 		D637A85E2974374C00C6DD7D /* LaunchAtLogin */ = {
 			isa = XCSwiftPackageProductDependency;

--- a/EjectKey.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/EjectKey.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -82,15 +82,6 @@
       }
     },
     {
-      "identity" : "swiftshell",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/kareman/SwiftShell",
-      "state" : {
-        "branch" : "master",
-        "revision" : "99680b2efc7c7dbcace1da0b3979d266f02e213c"
-      }
-    },
-    {
       "identity" : "swiftui-introspect",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/siteline/SwiftUI-Introspect.git",

--- a/EjectKey/Commands.swift
+++ b/EjectKey/Commands.swift
@@ -40,22 +40,33 @@ extension AppModel {
                     
                     if Defaults[.showQuitDialogWhenEjectionFails] {
                         DispatchQueue.global().async {
-                            let culprits = volume.getCulprits()
+                            let culpritApps = volume.getCulpritApps()
                             
-                            if culprits.isEmpty {
+                            if culpritApps.isEmpty {
                                 return
                             }
+                            
+                            let infoText = culpritApps.map({ app in
+                                if let name = app.localizedName {
+                                    return name
+                                } else if let bundleId = app.bundleIdentifier {
+                                    return bundleId
+                                } else {
+                                    let pid = app.processIdentifier
+                                    return String(pid)
+                                }
+                            }).joined(separator: "\n")
                             
                             DispatchQueue.main.async {
                                 self.alert(
                                     alertStyle: .warning,
                                     messageText: L10n.theFollowingApplicationsAreUsingVol(volume.name),
-                                    informativeText: culprits.map(\.name).joined(separator: "\n"),
+                                    informativeText: infoText,
                                     buttonTitle: L10n.quit,
                                     showCancelButton: true,
                                     hasDestructiveAction: true
                                 ) {
-                                    culprits.forEach({ $0.application.terminate() })
+                                    culpritApps.forEach({ $0.terminate() })
                                 }
                             }
                         }

--- a/EjectKey/Objects/Volume.swift
+++ b/EjectKey/Objects/Volume.swift
@@ -13,11 +13,6 @@ import Dispatch
 import Cocoa
 import SwiftShell
 
-struct Culprit: Equatable {
-    let name: String
-    let application: NSRunningApplication
-}
-
 class Volume {
 
     let disk: DADisk
@@ -123,7 +118,7 @@ class Volume {
         }
     }
 
-    func getCulprits() -> [Culprit] {
+    func getCulpritApps() -> [NSRunningApplication] {
         let volumePath = url.path(percentEncoded: false)
         let command = Command("/usr/sbin/lsof", ["-Fn", "+D", volumePath])
         
@@ -141,15 +136,8 @@ class Volume {
             }
         }).unique
         
-        let culprits = pids.compactMap({ pid in
-            if let app = NSRunningApplication(processIdentifier: pid),
-               let appName = app.localizedName {
-                return Culprit(name: appName, application: app)
-            } else {
-                return nil
-            }
-        })
+        let apps = pids.compactMap({ NSRunningApplication(processIdentifier: $0) })
         
-        return culprits
+        return apps
     }
 }

--- a/EjectKey/Objects/Volume.swift
+++ b/EjectKey/Objects/Volume.swift
@@ -11,7 +11,6 @@
 
 import Dispatch
 import Cocoa
-import SwiftShell
 
 class Volume {
 

--- a/EjectKey/Utils/Command.swift
+++ b/EjectKey/Utils/Command.swift
@@ -1,0 +1,32 @@
+//
+//  Command.swift
+//  EjectKey
+//
+//  Created by fus1ondev on 2023/07/23.
+//
+
+import Foundation
+
+class Command {
+    private let process: Process?
+    
+    init(_ command: String, _ arguments: [String]) {
+        process = Process()
+        process?.launchPath = command
+        process?.arguments = arguments
+    }
+
+    func run() -> String? {
+        let pipe = Pipe()
+        process?.standardOutput = pipe
+        process?.standardError = pipe
+        process?.launch()
+
+        let data = pipe.fileHandleForReading.readDataToEndOfFile()
+        let output = String(data: data, encoding: .utf8)
+
+        process?.waitUntilExit()
+
+        return output
+    }
+}


### PR DESCRIPTION
Closes #8

Currently, `lsof` command was executed many times, but by executing it only once, performance can be greatly improved.

Also, the SwiftShell library I was using to execute the command was a bit unstable, so I dropped the dependency on it and replaced it with a simple `Command` class.